### PR TITLE
Rajout listener Exception

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -21,9 +21,9 @@ nelmio_api_doc:
               description: Le status 202 veut dire que la requette a bien fonctionnée
             "400":
               description: Erreur de mot de passe
-            "402":
+            "401":
               description: Token d'authentification pas reconnu
-            "500":
+            "404":
               description: Identifiant inconnu dans la base
       /api/register:
         post:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -29,6 +29,9 @@ services:
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones
-    sensio_framework_extra.view.listener:
-        alias: Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener
+    # sensio_framework_extra.view.listener:
+    #     alias: Sensio\Bundle\FrameworkExtraBundle\EventListener\TemplateListener
+    App\EventListener\ExceptionListener:
+        tags:
+            - { name: kernel.event_listener, event: kernel.exception }
         

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -5,11 +5,9 @@ namespace App\Controller;
 use App\Entity\Users;
 use App\Entity\Clients;
 use App\Entity\ApiToken;
-use OpenApi\Annotations as OA;
 use App\Security\ApiTokenAuthenticator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use App\Exception\ResourceValidationException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use FOS\RestBundle\Controller\Annotations as Rest;
@@ -18,6 +16,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use OpenApi\Annotations as OA;
 
 /**
  * @Route("/api",name="api_")
@@ -31,7 +30,7 @@ class SecurityController extends AbstractFOSRestController
      *    path = "/register",
      *    name = "app_user_create"
      * )
-     * @Rest\View(StatusCode = 201,serializerGroups={"Show"})
+     * @Rest\View(StatusCode = 201)
      * @ParamConverter("user", converter="fos_rest.request_body")
      * 
      * @OA\Tag(name="Utilisateurs")
@@ -59,7 +58,7 @@ class SecurityController extends AbstractFOSRestController
             $entityManager->persist($user);
             $entityManager->flush();
 
-            return $this->view($user, Response::HTTP_CREATED, ['Location' => $this->generateUrl('api_app_user_login', ['', UrlGeneratorInterface::ABSOLUTE_URL])]);
+            return $this->view($user, Response::HTTP_CREATED, ['Location' => $this->generateUrl('app_security', ['', UrlGeneratorInterface::ABSOLUTE_URL])]);
     }
 
      /**
@@ -94,6 +93,7 @@ class SecurityController extends AbstractFOSRestController
         } else {
             return $this->view('Identifiant inconnu dans la base', Response::HTTP_NOT_FOUND);
         }
+        
     }
 
     /**

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -5,9 +5,11 @@ namespace App\Controller;
 use App\Entity\Users;
 use App\Entity\Clients;
 use App\Entity\ApiToken;
+use OpenApi\Annotations as OA;
 use App\Security\ApiTokenAuthenticator;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
+use App\Exception\ResourceValidationException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use FOS\RestBundle\Controller\Annotations as Rest;
@@ -16,7 +18,6 @@ use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-use OpenApi\Annotations as OA;
 
 /**
  * @Route("/api",name="api_")
@@ -30,7 +31,7 @@ class SecurityController extends AbstractFOSRestController
      *    path = "/register",
      *    name = "app_user_create"
      * )
-     * @Rest\View(StatusCode = 201)
+     * @Rest\View(StatusCode = 201,serializerGroups={"Show"})
      * @ParamConverter("user", converter="fos_rest.request_body")
      * 
      * @OA\Tag(name="Utilisateurs")
@@ -58,7 +59,7 @@ class SecurityController extends AbstractFOSRestController
             $entityManager->persist($user);
             $entityManager->flush();
 
-            return $this->view($user, Response::HTTP_CREATED, ['Location' => $this->generateUrl('app_security', ['', UrlGeneratorInterface::ABSOLUTE_URL])]);
+            return $this->view($user, Response::HTTP_CREATED, ['Location' => $this->generateUrl('api_app_user_login', ['', UrlGeneratorInterface::ABSOLUTE_URL])]);
     }
 
      /**
@@ -93,7 +94,6 @@ class SecurityController extends AbstractFOSRestController
         } else {
             return $this->view('Identifiant inconnu dans la base', Response::HTTP_NOT_FOUND);
         }
-        
     }
 
     /**

--- a/src/EventListener/ExceptionListener.php
+++ b/src/EventListener/ExceptionListener.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\EventListener;
+
+use JMS\Serializer\SerializerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class ExceptionListener
+{
+    private $serializer;
+
+    public function __construct(SerializerInterface $serializer)
+    {
+        $this->serializer = $serializer;
+    }
+
+    public function onKernelException(ExceptionEvent $event)
+    {
+        // You get the exception object from the received event
+        $exception = $event->getThrowable();
+        
+        $message = [
+            'message' => $exception->getMessage()
+        ];
+
+        $message = stripslashes(stripcslashes($this->serializer->serialize($message, "json")));
+
+        // Customize your response object to display the exception details
+        $response = new Response($message, 400, ["Content-Type" => "application/json"]);
+
+        // HttpExceptionInterface is a special type of exception that
+        // holds status code and header details
+        if ($exception instanceof HttpExceptionInterface) {
+            $response->setStatusCode($exception->getStatusCode());
+            $response->headers->replace($exception->getHeaders());
+        } else {
+            $response->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+
+        // sends the modified response object to the event
+        $event->setResponse($response);
+    }
+}

--- a/src/Security/ApiTokenAuthenticator.php
+++ b/src/Security/ApiTokenAuthenticator.php
@@ -73,7 +73,7 @@ class ApiTokenAuthenticator extends AbstractGuardAuthenticator
     {
         return new JsonResponse([
             'message' => 'Authentication Requise'
-        ], 402);
+        ], 401);
 
     }
 


### PR DESCRIPTION
Résolution du problème de renvoie de la stacktrace en html sur des codes erreurs 400(BadRequest) et 500(Serveur), en créant un service de listener de l'évenement kernel exception, afin de renvoyer les bonnes données.